### PR TITLE
Episode number in animation now hooked into SASS

### DIFF
--- a/client/src/animation/animator.js
+++ b/client/src/animation/animator.js
@@ -25,7 +25,8 @@ var Animator = function(opts) {
 
   this.width = opts.width || 400;
   this.height = opts.height || 400;
-  this.fontFamily = opts.fontFamily || '"Open Sans"';
+  this.fontFamily = opts.fontFamily || 'sans-serif';
+  this.fontFamilyEpNum = opts.fontFamilyEpNum || 'sans-serif';
 
   this.xPadding = 0.05;
   this.yPadding = 0.05; // text winds up at 5% of height
@@ -111,7 +112,7 @@ Animator.prototype = {
     const epNumY = this.height - this.yPadding * this.height - epNumFontSize/2.5;
     epNumText = new this.paper.PointText( new this.paper.Point(epNumX, epNumY));
     epNumText.style = {
-      fontFamily: 'Oswald',
+      fontFamily: this.fontFamilyEpNum,
       fillColor: this.textColor1,
       fontSize: epNumFontSize
     };

--- a/client/src/components/PreviewContainerComponent.js
+++ b/client/src/components/PreviewContainerComponent.js
@@ -106,6 +106,7 @@ class PreviewContainerComponent extends React.Component {
       width: this._canvasContainer.getBoundingClientRect().width,
       height: this._canvasContainer.getBoundingClientRect().height,
       fontFamily: scssVariables['$anim-font-family'].value,
+      fontFamilyEpNum: scssVariables['$anim-font-family-episode-number'].value,
       fps: this.fps,
       showNumber: this.props.showNumber,
       // footerImgBase64: this.refs._footerImg.src,

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -60,6 +60,7 @@ $anim-color-4: #000000;
 $anim-color-highlight-4: red;
 $anim-color-wave-4: $secondary-color;
 $anim-font-family: "Open Sans";
+$anim-font-family-episode-number: "Oswald";
 // This is the footer of the animation itself. It gets rendered into the final mp4.
 // It should be a 400x80 transparent PNG.
 $anim-footer-image: "animation-footer.png";


### PR DESCRIPTION
The font family of the episode number rendered in the
lower-left of the video is now driven by the SASS variable
`$anim-font-family-episode-number`.