### PR TITLE
Add upstream repository to server/package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,10 @@
     "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FeelTrainCoop/shortcut.git"
+  },
   "author": {
     "name": "Darius Kazemi",
     "email": "darius@feeltrain.com"


### PR DESCRIPTION



What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the following warning reported when doing initial setup of local installation/ development environment:

  `npm WARN shortcut-server@1.0.0 No repository field.`

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
n/a

On what OS and web browser did you test this?
---------------------------
Linux, Firefox 58

```bash
$ node --version
v6.11.4
$ npm --version
3.5.2
