### PR TITLE
Remove stray Yeoman generator config file

### DIFF
--- a/client/.yo-rc.json
+++ b/client/.yo-rc.json
@@ -1,8 +1,0 @@
-{
-  "generator-react-webpack": {
-    "appName": "talClient",
-    "style": "scss",
-    "postcss": true,
-    "generatedWithVersion": 3
-  }
-}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Whilst `yeoman` may have been used during initial, one-off generation of the project it is unlikely to be re-run. Remove the configuration file from upstream repository.

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
Unlikely to be run again as:
1. `yeoman` itself isn't a dependency of this project, and
2. low likelihood of re-running a project generator after v1.0.0 has been released without a major refactor.

On what OS and web browser did you test this?
---------------------------
Linux, Firefox 58
