### PR TITLE
server: Update server project name to abstract away from tal

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -2,9 +2,9 @@
 
 Please refer to [the wiki](https://github.com/FeelTrainCoop/shortcut/wiki) instead. This README will soon be updated to reflect the current state of the project.
 
-# tal-server
+# shortcut-server
 A node/express server that
-- serves a single page application ("tal-client")
+- serves a single page application ("shortcut-client")
 - provides an API for handling social authentication for the client. Currently Twitter and Facebook are supported.
 - provides web hooks for updating individual episodes and the list of available episodes
 - ensures that only authorized requests can access episode data
@@ -28,8 +28,8 @@ Copy `.env-template` to `.env` and fill in environment variables.
 
 ### Build & run with Docker:
 - Mac only: eval "$(docker-machine env default)"
-- `docker build -t tal-server .`
-- `docker run -p 3000:3000 -d tal-server`
+- `docker build -t shortcut-server .`
+- `docker run -p 3000:3000 -d shortcut-server`
 - server will be running at docker-machine ip, i.e. `http://192.168.99.100:3000/`
 
 ### Run with Node:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "tal-auth-server",
+  "name": "shortcut-server",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Update documentation and example commands in `server/` to reflect new project name.

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
Follows changes in https://github.com/FeelTrainCoop/shortcut/commit/e0d2d8d47c022b5104a9ae229abb75d02fc4cbef

On what OS and web browser did you test this?
---------------------------
Linux, Firefox 58
