### PR TITLE
Add nodemon to shortcut-server devDependencies

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -16,7 +16,6 @@ A node/express server that
 ##### Install dependencies
 ```
 npm install
-npm install -g nodemon
 ```
 
 ##### Env Variables

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,9 @@
     "email": "darius@feeltrain.com"
   },
   "license": "GPL-3.0",
+  "devDependencies": {
+    "nodemon": "^1.10.0"
+  },
   "dependencies": {
     "async": "^2.5.0",
     "aws-cloudfront-sign": "^2.1.2",


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Documentation and package.json provide guidance to using nodemon to ease the development process. However, it was missing from devDependencies in `server/package.json` and a manual install instruction in `server/README.md`

As npm has functionality to reflect dependencies that should not be run in `--production` (or when the `NODE_ENV` environment variable is set to `production`) then let's utilize that.

This reduces the number of manual commands that must be run to setup the recommended `shortcut` development environment.

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
…

On what OS and web browser did you test this?
---------------------------
Linux
