### PR TITLE
client: Add missing peer dependency flexboxgrid

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -85,6 +85,7 @@
     "express": "~4.13.4",
     "express-session": "~1.13.0",
     "fbgraph": "~1.1.0",
+    "flexboxgrid": "^6.3.0",
     "hls.js": "~0.6.2-3",
     "jquery": "^3.3.1",
     "material-ui": "^1.0.0-beta.13",


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Without this peer dependency of `react-flexbox-grid@0.9.6`, the following error message is reported when running `npm install`:
```
  shortcut-client@1.0.0 /home/rhyskidd/Coding/shortcut/client
  └── UNMET PEER DEPENDENCY flexboxgrid@^6.3.0

  npm WARN react-flexbox-grid@0.9.6 requires a peer of flexboxgrid@^6.3.0 but none was installed.
```
Reported with:
```
  $ npm --version
  3.5.2
  $ nodejs --version
  v6.11.4
```

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
For more on peer dependencies, see: https://stackoverflow.com/a/22004559/4206728

On what OS and web browser did you test this?
---------------------------
Linux, Firefox 58
