### PR TITLE
client: Replace deprecated babel-preset-es2015 with babel-preset-env

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    "env",
     "react"
   ]
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -899,38 +899,6 @@
         }
       }
     },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.0.0",
     "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.0.15",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.0.15",
     "base64-image-loader": "^1.0.0",
     "bower-webpack-plugin": "^0.1.9",


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
A Babel preset that compiles ES2015+ down to ES5 by automatically determining the Babel plugins and polyfills you need based on your targeted browser or runtime environments.

Fixes warning:
```
npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel:
we recommend using babel-preset-env now: please read babeljs.io/env to update!
```
No regressions in `client` test suite from this refactor.

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
…

Any other comments?
-------------------
Comments:
  - [Do not target specific browsers](https://babeljs.io/env#by-targeting-specific-browsers-babel-can-do-less-work-so-you-can-ship-native-es2015-), to preserve broadest possible support.
  - Remove prior `package-lock.json` artifacts, which are used by npm >= 5.

On what OS and web browser did you test this?
---------------------------
Linux, Firefox 58
```
$ npm --version
3.5.2
$ nodejs --version
v6.11.4
```

