### PR TITLE
Add preliminary Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+
+node_js:
+  - "6"
+  - "8"
+
+addons:
+  apt:
+    packages:
+      - libcairo2-dev
+      - libgif-dev
+      - libjpeg-dev
+      - libpng-dev
+
+env:
+  # Run each sub-folder separately in the build matrix
+  - TEST_DIR=client
+  - TEST_DIR=server
+
+install:
+  - ./setup.sh
+  - cd $TEST_DIR
+  - npm install
+
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ node_js:
   - "6"
   - "8"
 
+cache:
+  directories:
+    - client/node_modules
+    - server/node_modules
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds preliminary support for continuous integration, specifically via the Travis-CI platform.

[Travis-CI](https://travis-ci.org/) is a cloud-hosted continuous integration platform, with good quality GitHub integration and free for open source projects.

How to enable:
* Individual developers who forked `shortcut` can [enable Travis-CI](https://docs.travis-ci.com/user/getting-started/) on their own GitHub-hosted fork, via Travis-CI's GitHub integration. This allows each developer's branches to be run through CI.
* @dariusk could enable Travis-CI for this upstream repo, turning on automated CI testing of all incoming PRs `<branches>` and `master` branch (with a potential status badge in `README.md`)

Does this close any currently open issues?
------------------------------------------
Partial fix for https://github.com/FeelTrainCoop/shortcut/issues/57

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
At present the status of each node package is:
- `client`: 3 of 15 tests are known failing at the moment.
- `server`: No current tests. The test-runner is in place for Travis-CI to run these once written.

After a successful `client` run of `npm run test`, `eslint` will be run over `client/src` indirectly via the posttest script.

On what OS and web browser did you test this?
---------------------------
Travis-CI's default environment, which is Ubuntu 14.04 LTS (Trusty Tahr).
