### PR TITLE
Bump version number in subfolder packages to 1.1.0 as well

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shortcut-client",
   "description": "Shortcut Client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "GPL-3.0",
   "main": "",
   "scripts": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shortcut Server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Given most of the logs users will produce have version numbers derived from these package.json files, it's equally important to mirror the overall version number change here -- otherwise user bug reports will be hard to link to a specific release of Shortcut.

Let's prepare for an influx of potential users, whilst making devs' lives easier :)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes output like `> shortcut-client@1.0.0 <some _command>` in the **v1.1.0** release.

Does this close any currently open issues?
------------------------------------------
n/a

Any specific code you'd like to call attention to for review?
-------------------------------------
n/a

Any other comments?
-------------------
n/a

On what OS and web browser did you test this?
---------------------------
Linux, Firefox 59
